### PR TITLE
Použít url_for na obrázek v metadatech pro Facebook a Twitter

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -19,14 +19,14 @@
       <meta name="description" content="České PyLadies - týdenní srazy a kurzy pro holky, slečny či ženy co se chtějí učit programovat v Pythonu. Momentálně v Praze a Brně."></meta>
       <meta property="og:title" content="PyLadies CZ"></meta>
       <meta property="og:type" content="article"></meta>
-      <meta property="og:image" content="https://github.com/PyLadiesCZ/pyladies.cz/blob/master/static/img/bg/intro.jpg"></meta>
+      <meta property="og:image" content="{{ url_for('static', filename='img/bg/intro.jpg') }}"></meta>
       <meta property="og:url" content="www.pyladies.cz"></meta>
       <meta property="og:description" content="České PyLadies - týdenní srazy a kurzy pro holky, slečny či ženy co se chtějí učit programovat v Pythonu. Momentálně v Praze a Brně. Pro přehled otevřených kurzů sleduj náš web www.pyladies.cz"></meta>
       <meta name="twitter:card" content="summary"></meta>
       <meta name="twitter:title" content="PyLadies CZ"></meta>
       <meta name="twitter:site" content="@PyLadiesCZ"></meta>
       <meta name="twitter:description" content="České PyLadies - týdenní srazy a kurzy pro holky, slečny či ženy co se chtějí učit programovat v Pythonu. Momentálně v Praze a Brně. Pro přehled otevřených kurzů sleduj náš web www.pyladies.cz"></meta>
-      <meta name="twitter:image" content="https://github.com/PyLadiesCZ/pyladies.cz/blob/master/static/img/bg/intro.jpg"></meta>
+      <meta name="twitter:image" content="{{ url_for('static', filename='img/bg/intro.jpg') }}"></meta>
 
       <title>{% block title %}PyLadies CZ{% endblock title %}</title>
 


### PR DESCRIPTION
Ukazovalo to kamsi na Github, kde se adresa už nejspíš změnila. Takhle to bude ukazovat na obrázek z pyladies.cz.

Fixes #153