### PR TITLE
Upper index replaced with number.

### DIFF
--- a/original/v1/s002-hello-world/comparisons.html
+++ b/original/v1/s002-hello-world/comparisons.html
@@ -121,7 +121,7 @@ print(False)
 <pre>
 strana = float(input('Zadej stranu v centimetrech: '))
 print('Obvod čtverce se stranou', strana, 'je', 4 * strana, 'cm')
-print('Obsah čtverce se stranou', strana, 'je', strana * strana, 'cm²')
+print('Obsah čtverce se stranou', strana, 'je', strana * strana, 'cm2')
 </pre>
 
                     </p>


### PR DESCRIPTION
V úvodu do podmínek je v jednom příkladu utf8 znak pro horní index u centimetrů čtverečních, což je jednak jiné než u zbytku příkladů a jednak to při copy-paste rozbije program.

Pokud to nebyl účel, prosím o merge, který to opraví.