### PR TITLE
Nahraď ² sprostou dvojkou.

### DIFF
--- a/original/v1/s002-hello-world/comparisons.html
+++ b/original/v1/s002-hello-world/comparisons.html
@@ -121,7 +121,7 @@ print(False)
 <pre>
 strana = float(input('Zadej stranu v centimetrech: '))
 print('Obvod čtverce se stranou', strana, 'je', 4 * strana, 'cm')
-print('Obsah čtverce se stranou', strana, 'je', strana * strana, 'cm²')
+print('Obsah čtverce se stranou', strana, 'je', strana * strana, 'cm2')
 </pre>
 
                     </p>
@@ -152,7 +152,7 @@ cislo_je_spravne = strana &gt;= 0
 
 if cislo_je_spravne:
     print('Obvod čtverce se stranou', strana, 'je', 4 * strana, 'cm')
-    print('Obsah čtverce se stranou', strana, 'je', strana * strana, 'cm²')
+    print('Obsah čtverce se stranou', strana, 'je', strana * strana, 'cm2')
 else:
     print('Už jsi někdy viděla záporný čtverec?')
 

--- a/original/v1/s004-strings/functions.html
+++ b/original/v1/s004-strings/functions.html
@@ -161,7 +161,7 @@ from math import pi
 def obsah_elipsy(a, b):
     return pi * a * b
 
-print('Obsah elipsy s osami 3 cm a 5 cm je', obsah_elipsy(3, 5), 'cm²')
+print('Obsah elipsy s osami 3 cm a 5 cm je', obsah_elipsy(3, 5), 'cm2')
 </pre>
 </details>
                     </section>


### PR DESCRIPTION
Na windowsových počítačích unicodová dvojka rozbije spouštění příkazovou řádkou. Nelze ji totiž převést do cp1250. Obyčejná dvojka je sice ošklivější, zato spolehlivější.