### PR TITLE
Drobná zpříjemnění jabkařům.

### DIFF
--- a/course/intro-cmdline.rst
+++ b/course/intro-cmdline.rst
@@ -14,7 +14,7 @@ se na různých systémech otevírá různě:
 
 * **Windows** (české): Start → Všechny programy → Příslušenství → Příkazový řádek
 * **Windows** (anglické): Start → All Programs → Accessories → Command Prompt
-* **Mac OS X** (anglické): Applications → Utilities → Terminal
+* **macOS** (anglické): Applications → Utilities → Terminal
 * **Linux** (KDE): Hlavní Menu → hledat Konsole
 * **Linux** (Gnome): Super → hledat Terminál
 
@@ -28,7 +28,7 @@ před nímž můžou být ještě další informace:
 
 .. container:: col-md-6 os-unix
 
-    **Unix (Linux, OS X)**::
+    **Unix (Linux, macOS)**::
 
     $
 

--- a/course/intro-cmdline.rst
+++ b/course/intro-cmdline.rst
@@ -14,6 +14,7 @@ se na různých systémech otevírá různě:
 
 * **Windows** (české): Start → Všechny programy → Příslušenství → Příkazový řádek
 * **Windows** (anglické): Start → All Programs → Accessories → Command Prompt
+* **macOS** (český): Aplikace → Utility → Terminál
 * **macOS** (anglické): Applications → Utilities → Terminal
 * **Linux** (KDE): Hlavní Menu → hledat Konsole
 * **Linux** (Gnome): Super → hledat Terminál

--- a/original/course.html
+++ b/original/course.html
@@ -52,7 +52,7 @@
                     <p>
                         Je potřeba základní znalost práce s počítačem
                         (pokud umíš posílat e-maily, jsi v pohodě).
-                        Instrukce máme pro operační systémy Linux, Windows a Mac OS X.
+                        Instrukce máme pro operační systémy Linux, Windows a macOS.
                     </p>
                     <p>
                         Je potřeba počítač, na který jdou instalovat programy.

--- a/original/v1/s001-install/cmdline.html
+++ b/original/v1/s001-install/cmdline.html
@@ -28,6 +28,7 @@
                         <ul>
                             <li>Windows (cs): Start → Všechny programy → Příslušenství → Příkazový řádek</li>
                             <li>Windows (en): Start → All Programs → Accessories → Command Prompt</li>
+                            <li>macOS (cs): Aplikace → Utility → Terminál</li>
                             <li>macOS (en): Applications → Utilities → Terminal</li>
                             <li>Linux (KDE): Hlavní Menu → hledat Konsole</li>
                             <li>Linux (Gnome): Super → hledat Terminál</li>

--- a/original/v1/s001-install/cmdline.html
+++ b/original/v1/s001-install/cmdline.html
@@ -28,7 +28,7 @@
                         <ul>
                             <li>Windows (cs): Start → Všechny programy → Příslušenství → Příkazový řádek</li>
                             <li>Windows (en): Start → All Programs → Accessories → Command Prompt</li>
-                            <li>Mac OS X (en): Applications → Utilities → Terminal</li>
+                            <li>macOS (en): Applications → Utilities → Terminal</li>
                             <li>Linux (KDE): Hlavní Menu → hledat Konsole</li>
                             <li>Linux (Gnome): Super → hledat Terminál</li>
                         </ul>
@@ -44,7 +44,7 @@
                         </p>
                     </div>
                     <div  class="col-lg-6">
-                        <h4>Unix (Linux, OS X)</h4>
+                        <h4>Unix (Linux, macOS)</h4>
 <pre>
 $
 </pre>

--- a/original/v1/s001-install/git.html
+++ b/original/v1/s001-install/git.html
@@ -96,7 +96,7 @@
                     </div>
                 </section>
                 <section class="col-lg-12">
-                    <h2>Mac OS X</h2>
+                    <h2>macOS</h2>
                     Spusť v příkazové řádce <code>git</code>.
                     Je-li už nainstalovaný, dozvíš se, jak ho používat
                     (výpis začíná <code>usage</code>).

--- a/original/v1/s001-install/instalace.html
+++ b/original/v1/s001-install/instalace.html
@@ -29,7 +29,7 @@
                         Příště to bude jednodušší!
                     </div>
                     <div>
-                        Pokud máš jiný systém než Windows nebo Linux (např. Mac OS X),
+                        Pokud máš jiný systém než Windows nebo Linux (např. macOS),
                         nebo pokud ke svému počítači neznáš administrátorské heslo (např. u RHEL CSB),
                         poraď se s koučem hned, jinak se ptej, až bude něco nejasné.
                         Nejsi-li na srazu, zeptej se přes e-mail.
@@ -61,7 +61,7 @@
                     </p>
                     <div class="text-center"><img src="./windows_add_python_to_path.png"></img></div>
 
-                    <h3>OS X</h3>
+                    <h3>macOS</h3>
                     <p>
                         Drž se instrukcí pro Windows, ale stáhni instalátor pro <em>Mac OS X</em>,
                         podle verze tvého systému.
@@ -167,7 +167,7 @@ $ <b>sudo dnf install python3-tk</b>
 </pre>
                 </div>
                 <div class="col-lg-4">
-                    <h4>Linux/OS X, Python 3.4 a 3.5</h4>
+                    <h4>Linux/macOS, Python 3.4 a 3.5</h4>
 <pre>
 $ <b>python3 -m venv venv</b>
 </pre>

--- a/original/v1/s002-hello-world/editor.html
+++ b/original/v1/s002-hello-world/editor.html
@@ -27,7 +27,7 @@
                         Je víceméně jedno, který editor budeš používat;
                         pokud už nějaký oblíbený máš, stačí ho jen nastavit.
                         Pokud ale používáš Poznámkový blok (Notepad) z Windows,
-                        nebo editor předinstalovaný v Mac OS X,
+                        nebo editor předinstalovaný v macOS,
                         nebude ti stačit.
                         Stejně tak nejsou vhodné programy jako Word
                         či Writer.<br>

--- a/original/v1/s005-modules/cmdline.html
+++ b/original/v1/s005-modules/cmdline.html
@@ -22,7 +22,7 @@
                         <h1>Soubory, adresáře, a příkazová řádka do hloubky</h1>
                         <div>
                             Dnes si povíme, jak fungují systémy založené na
-                            UNIXu, jako Linux a OS X.
+                            UNIXu, jako Linux a macOS.
                         </div>
                         <div class="note">
                             Windows fungují podobně, takže se tyhle znalosti
@@ -529,7 +529,7 @@ $ python
                         <div>
                             Je možné psát si vlastní příkazy pro
                             příkazovou řádku.
-                            Pokud máš Linux (nebo Mac OS) a věříš si,
+                            Pokud máš Linux (nebo macOS) a věříš si,
                             můžeš to zkusit.
                             Je to ale tak trochu nad rámec PyLadies :)
                         </div>

--- a/original/v1/s009-git/git.html
+++ b/original/v1/s009-git/git.html
@@ -191,7 +191,7 @@ $ git commit
                         (<kbd>Alt</kbd>+<kbd>F4</kbd>).
                         </p>
                         <p>
-                        Na Linuxu a Mac OS X se objeví editor v příkazové řádce,
+                        Na Linuxu a macOS se objeví editor v příkazové řádce,
                         který se jmenuje Nano.
                         Pozná se tak, že v dolních dvou řádcích má malou nápovědu.
                         Něco napiš, pomocí <kbd>Ctrl</kbd>+<kbd>O</kbd>

--- a/original/v1/s012-pyglet/pong.py
+++ b/original/v1/s012-pyglet/pong.py
@@ -39,7 +39,7 @@ knihovnami. OpenGL pouziva matematicky souradny system, nula je vlevo *dole*.
 """
 
 # Prvni radek (#!/usr/bin/env python3) je takzvany "shebang": na systemech
-# zalozenych na Unixu (Linux, OS X) umoznuje spustit tenhle soubor jednoduse
+# zalozenych na Unixu (Linux, macOS) umoznuje spustit tenhle soubor jednoduse
 # pomoci prikazu: ./pong.py
 
 # A ted uz k samotne hre: napred naimportujeme potrebne veci z knihovny pyglet

--- a/templates/index.html
+++ b/templates/index.html
@@ -224,7 +224,7 @@
             <a href="">
                 <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 material">
                   <img src="{{ pathto('_static/img/icon/os-mac.png', 1) }}" class="mac-icon comp-icon" /><br />
-                  Mac OS
+                  macOS
                 </div>
             </a>
             <a href="">


### PR DESCRIPTION
* Když si dnes někdo koupí Mac, už ani nemusí vědět, že se operační systém někdy jmenoval ([Mac](http://arstechnica.com/apple/2016/09/macos-10-12-sierra-the-ars-technica-review/)) OS X. I starším verzím se dnes zpětně říká macOS.
* macOS již docela dlouho umí česky. Kdo si ho pořídí u nás, tím spíše rodem neprogramista, bude tam mít česká hejblátka.