### PR TITLE
Brát informace na hlavní stránce z yamlů v meetups

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,58 +81,83 @@ statické stránky k nasazení na webový server.:
 
     $ python pyladies_cz.py freeze
 
-## Základní informace o kurzech, které se často mění - editace HTML
+### <a name="kurzy-mesta">Aktuální a proběhlé kurzy (stránka kurzů se upravuje v souboru `meetups/brno.yml`)
+Každé město má vlastní stránku s aktuálními a proběhlými kurzy. Dříve či později se z toho stane taková kronika.
 
-### <a name="uvodni-stranka">Nastavení aktuálních kurzů na úvodní stránce <br /><br />
-**Nezapomeň vždy změnit {{ pathto('mesto') }} pro dané město!**
+První kurz v seznamu se ukáže na hlavní stránce.
 
-<img src="https://github.com/PyLadiesCZ/pyladies.cz/blob/master/static/img/icon/pylady.png" width=100 height=55 /><br /> - kurz, který právě běží. Ikonka - obrázek pylady.png. Kód:
+***V meetupech lze nastavit:***
+
+* `name`: jméno akce
+
+* `topic`: téma akce
+
+* `start` a `end`: datum ve formátu `2017-02-13`, pokud má akce pevný termín od do
+
+* `date`: datum jednodenní akce (`start` a `end` by byly stejné)
+
+* `time`: čas od do, případně i den v týdnu
+
+* `place`: místo, kde sraz probíhá (pokud je víc srazů v jednom místě, dá se v YAMLu místo nasdílet dalším srazům, viz ukázky v těch YAML souborech)
+
+    * `name`: jméno místa
+    * `address`: adresa
+    * `latitude`, `longitude`: mapové souřadnice
+    * `url`: odkaz (chybí-li, ukáže se odkaz na mapu podle latitude/longitude)
+
+* `registration`: informace o registraci
+
+    * `url`: odkaz na registrační formulář
+    * `end`: konec registrace (dá se vynechat, pokud je registrace aktuální až do konce kurzu – třeba u opakujících se srazů)
+    * `text`: text, který se objeví v odkazu (místo "Registrace právě probíhá!")
+
+* `parallel-with-previous`: `true` pokud je kurz paralelní s předchozím.
+  (Informace o paralelních kurzech se občas zobrazují společně.)
+
+
+***Ukázky variant kurzu (dají se kombinovat):***
+
+** Kurz má jasný start a konec, místo, čas registraci**
+
 ```
-<div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 course-i">
-  <div class="py-icon">
-    <img src="{{ pathto('_static/img/icon/pylady.png', 1) }}" class="py-icon-i" />
-  </div>
-  <div class="py-block pull-left">
-    <a href="{{ pathto('praha') }}"><h4 class="city-heading">Praha - začátečnický kurz</h4>
-    <p class="city-info">01.01. - 31.04. 2016</p>
-    <p class="city-address">
-      <a href="https://www.google.cz/maps/place/Florentinum/@50.0888957,14.4353417,15z/data=!4m2!3m1!1s0x0:0x90e42b8069106734" target="new">Na Florenci 2116/15, 110 00</a>
-    </p>
-  </div>
-</div>
+- name: Začátečnický kurz <br> Jarní pondělí 2017
+  start: 2017-02-27
+  end: 2017-05-29
+  time: pondělky 18:00 – 20:00
+  place:
+    name: Odbor školství
+    address: Cejl 73, Brno
+    latitude: '49.1992294'
+    longitude: '16.6235206'
+  registration:
+    url: <tady_bude_adresa>
+    end: 2017-02-19
 ```
 
-<img src="https://github.com/PyLadiesCZ/pyladies.cz/blob/master/static/img/icon/pylady-grey.png" width=100 height=55 /><br /> - kurz, který právě nebeží a není spuštěná registrace. Ikonka - obrázek pylady-grey.png. Kód:
+** Kurz je jednodenní a má například téma**
+
 ```
-<div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 course-i">
-    <div class="py-icon">
-      <img src="{{ pathto('_static/img/icon/pylady-grey.png', 1) }}" class="py-icon-i" />
-    </div>
-    <div class="py-block pull-left">
-      <a href="{{ pathto('brno') }}"><h4 class="city-heading">Brno - začátečnický kurz</h4>
-      <p class="city-info">Kurz právě neprobíhá.</p>
-      <p class="city-address">
-        <a href="mailto: a@a.com">Napiš nám.</a>
-      </p>
-    </div>
-</div>
+- name: Lednový PyWorking <br> meetup pro pokročilé začátečníky
+  topic: Django Polls
+  date: 2017-01-28
+  time: 9:00 - 17:30
+  place:
+    name: MSD IT (Riverview)
+    address: Svornosti 3321/2, Praha 5
+    latitude: '50.0670442'
 ```
 
-<img src="https://github.com/PyLadiesCZ/pyladies.cz/blob/master/static/img/icon/pylady-blue.png" width=100 height=55 /><br /> - kurz, který právě nebeží, ale je spuštěná registrace. Ikonka - obrázek pylady-blue.png. Kód:
+** Jsou to pravidelné srazy**
+
 ```
-<div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 course-i">
-  <div class="py-icon">
-    <img src="{{ pathto('_static/img/icon/pylady-blue.png', 1) }}" class="py-icon-i" />
-  </div>
-  <div class="py-block pull-left">
-    <a href="{{ pathto('ostrava') }}"><h4 class="city-heading">Ostrava - začátečnický kurz</h4>
-    <p class="city-info">Proběhne od 01.01. - 31.04. 2016</p>
-    <p class="city-address">
-      <a href="#">Registrační formulář</a>
-    </p>
-  </div>
-</div>
+- name: Advanced PyLadies & PyWorking Praha <br> pokročilé a doučovací srazy
+  time: pondělky ve 14 denních intervalech, 18:00 - 20:00
+  registration:
+    url: <tady_bude_adresa>
 ```
+    
+
+
 ### <a name="nastaveni-obrazku">Nastavení obrázků
 
 * Banner na úvodní stránce - 1500px × 655px
@@ -205,74 +230,3 @@ Každé město může mít vlastní plán kurzu. Případně navíc speciální 
   - name: Relační databáze
     type: special-lesson
 ```
-
-### <a name="kurzy-mesta">Aktuální a proběhlé kurzy (stránka kurzů se upravuje v souboru `meetups/brno.yml`)
-Každé město má vlastní stránku s aktuálními a proběhlými kurzy. Dříve či později se z toho stane taková kronika.
-
-***V meetupech lze nastavit:***
-
-name: jméno akce
-
-topic: téma akce
-
-start a end: datum ve formátu `2017-02-13`, pokud má akce pevný termín od do
-
-date: jednodenní akce
-
-time: čas od do, případně i den v týdnu
-
-place: místo, kde sraz probíhá (pokud je víc srazů v jednom místě, dá se v YAMLu místo nasdílet dalším srazům, viz ukázky v těch YAML souborech)
-
-* name: jméno
-* address: adresa
-* latitude, longitude: mapové souřadnice
-* url: odkaz (chybí-li, ukáže se odkaz na mapu podle latitude/longitude)
-
-registration:
-
-* url: odkaz na registrační formulář
-* end: konec registrace (dá se vynechat, pokud je registrace vždy aktuální, třeba u opakujících se srazů)
-* text: text, který se objeví v odkazu (místo "Registrace právě probíhá!")
-
-
-***Ukázky variant kurzu (dají se kombinovat):***
-
-** Kurz má jasný start a konec, místo, čas registraci**
-
-```
-- name: Začátečnický kurz <br> Jarní pondělí 2017
-  start: 2017-02-27
-  end: 2017-05-29
-  time: pondělky 18:00 – 20:00
-  place:
-    name: Odbor školství
-    address: Cejl 73, Brno
-    latitude: '49.1992294'
-    longitude: '16.6235206'
-  registration:
-    url: <tady_bude_adresa>
-    end: 2017-02-19
-```
-
-** Kurz je jednodenní a má například téma**
-
-```
-- name: Lednový PyWorking <br> meetup pro pokročilé začátečníky
-  topic: Django Polls
-  date: 2017-01-28
-  time: 9:00 - 17:30
-  place:
-    name: MSD IT (Riverview)
-    address: Svornosti 3321/2, Praha 5
-    latitude: '50.0670442'
-```
-
-** Jsou to pravidelné srazy**
-
-```
-- name: Advanced PyLadies & PyWorking Praha <br> pokročilé a doučovací srazy
-  time: pondělky ve 14 denních intervalech, 18:00 - 20:00
-  registration:
-    url: <tady_bude_adresa>
-```
-    

--- a/meetups/brno.yml
+++ b/meetups/brno.yml
@@ -12,6 +12,7 @@
     longitude: '16.6064981'
 
 - name: Začátečnický kurz <br> Podzimní středa 2017
+  parallel-with-previous: true
   registration:
     url: https://docs.google.com/forms/d/1ijtXfsv2nIj0zeCWGKcRlHvZcWc_rvktktITdg9GZJs
     end: 2017-09-03
@@ -35,6 +36,7 @@
     longitude: '16.6235206'
 
 - name: Začátečnický kurz <br> Jarní úterý 2017
+  parallel-with-previous: true
   start: 2017-02-28
   end: 2017-05-30
   time: úterky 18:00 – 20:00

--- a/meetups/praha.yml
+++ b/meetups/praha.yml
@@ -2,6 +2,8 @@
   start: 2017-09-19
   end: 2017-12-12
   time: každé úterý 18:00 - 20:00
+  registration:
+    url: https://goo.gl/forms/PwQU4TanL6ZpSwNE3
   place: &cz-nic
     name: budova CZ.NIC
     address: Milešovská 5, Praha 3

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -407,6 +407,9 @@ CITIES PAGE
     font-weight: bold;
     color: #333;
 }
+.city-heading a {
+    color: #333;
+}
 .city-info,
 .city-address a {
     color: #8e8c8d;

--- a/templates/index.html
+++ b/templates/index.html
@@ -74,46 +74,49 @@
     </section>
     <!-- Courses section -->
     <section class="course-wrapper container-fluid" id="main-course">
-        <!-- PRAHA AKTUÁLNĚ -->
-        <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 course-i">
-            <div class="py-icon">
-                <img src="{{ pathto('_static/img/icon/pylady-blue.png', 1) }}" class="py-icon-i" />
+        {% for city_name, meetups in current_meetups.items() %}
+            {% set meetup = meetups[0] %}
+            <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 course-i">
+                <div class="py-icon">
+                    {% if meetup.registration_status in ('meetup_started', 'closed') %}
+                    <img src="{{ pathto('_static/img/icon/pylady.png', 1) }}" class="py-icon-i" />
+                    {% elif meetup.registration_status == 'running' %}
+                    <img src="{{ pathto('_static/img/icon/pylady-blue.png', 1) }}" class="py-icon-i" />
+                    {% else %}
+                    <img src="{{ pathto('_static/img/icon/pylady-grey.png', 1) }}" class="py-icon-i" />
+                    {% endif %}
+                </div>
+                <div class="py-block pull-left">
+                    <h4 class="city-heading">
+                        <a href="{{ pathto(city_name) }}">
+                        {{ city_name | title }} - začátečnický kurz
+                        </a>
+                    </h4>
+                    <p class="city-info">
+                        {% for c in meetup.parallel_runs %}
+                            {% if not loop.first %}/<br>{% endif %}
+                            {{ (c.start, c.end)| date_range }}
+                        {% endfor %}
+                        {% if meetup.registration_status == 'running' %}
+                            <a target="_blank" href="{{ meetup.registration.url }}">
+                                {{ meetup.registration.get('text', 'Registrace zde!') }}
+                            </a>
+                        {% endif %}
+                    </p>
+                    {% if meetup.place %}
+                      <p class="city-address">
+                      {% for c in meetup.parallel_runs %}
+                        {% if not loop.first %}/{% endif %}
+                          <a href="{{ c.place.url }}" target="_blank">
+                            {{ c.place.name }},
+                            {{ c.place.address }}
+                          </a>
+                        {% endfor %}
+                      </p>
+                    {% endif %}
+                </div>
             </div>
-            <div class="py-block pull-left">
-                <a href="{{ pathto('praha') }}"><h4 class="city-heading">Praha - začátečnický kurz</h4>
-                <p class="city-info">19. 9. - 12. 12. 2017 <a target="_blank" href="https://goo.gl/forms/PwQU4TanL6ZpSwNE3">Registrace zde!</a></p>
-                <p class="city-address">
-                    <a href="https://www.google.cz/maps/place/CZ.NIC,+z.+s.+p.+o./@50.079123,14.4490963,17z/data=!3m1!4b1!4m2!3m1!1s0x417314ec0f1850d3:0x7fea48d126f93e72?hl=cs" target="_blank">budova CZ.NIC, Milešovská 5, Praha 3</a>
-                </p>
-            </div>
-        </div>
-        <!-- BRNO AKTUÁLNĚ-->
-        <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 course-i">
-            <div class="py-icon">
-                <img src="{{ pathto('_static/img/icon/pylady.png', 1) }}" class="py-icon-i" />
-            </div>
-            <div class="py-block pull-left">
-                <a href="{{ pathto('brno') }}"><h4 class="city-heading">Brno - začátečnický kurz</h4></a>
-                <p class="city-info">25. 9. – 18. 12. 2017 / <br>27. 9. – 20. 12. 2017</p>
-                <p class="city-address">
-                   <a href="https://mapy.cz/s/17fac" target="_blank">Experis, Nové sady 996/25</a> /
-                   <a href="https://goo.gl/miAzTf" target="_blank"> SolarWinds, Holandská 873/6</a>
-                </p>
-            </div>
-        </div>
-        <!-- OSTRAVA AKTUÁLNĚ -->
-        <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 course-i">
-            <div class="py-icon">
-                <img src="{{ pathto('_static/img/icon/pylady.png', 1) }}" class="py-icon-i" />
-            </div>
-            <div class="py-block pull-left">
-                <a href="{{ pathto('ostrava') }}"><h4 class="city-heading">Ostrava - začátečnický kurz</h4></a>
-                <p class="city-info">12. 9. - 19. 12. 2017</p>
-                <p class="city-address">
-                    <a href="https://goo.gl/maps/rq7CrLf9x2A2" target="_blank">Tieto Towers, 28.října 3346/91, Ostrava</a>
-                </p>
-            </div>
-        </div>
+        {% endfor %}
         <div class="col-md-3 hidden-sm hidden-xs course-i text-center">
             <a href="http://pyladies.cz/stan_se/"><div class="new-city">Založ vlastní PyLadies</div></a>
         </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -134,36 +134,37 @@
 {% endmacro %}
 
 {% macro meetup_list(meetups) %}
-    {% if meetups['current'] %}
-      <div class="row">
-        <div class="col-xs-12 col-sm-12 col-md-offset-1 col-lg-offset-1 col-lg-10 col-md-10">
-          <h2 class="course-city-heading">Aktuální kurzy a srazy</h2>
-        </div>
+    <div class="row">
+      <div class="col-xs-12 col-sm-12 col-md-offset-1 col-lg-offset-1 col-lg-10 col-md-10">
+        <h2 class="course-city-heading">Aktuální kurzy a srazy</h2>
       </div>
-      <div class="row">
-        {% for meetup in meetups['current'] %}
-          {{ meetup_info(meetup) }}
+    </div>
+    <div class="row">
+      {% for meetup in meetups %}
+        {% if meetup.current %}
+         {{ meetup_info(meetup) }}
           {% if not loop.last and loop.index0 % 2 %}
             </div><div class="row">
           {% endif %}
-        {% endfor %}
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <div class="row">
+      <div class="col-xs-12 col-sm-12 col-md-offset-1 col-lg-offset-1 col-lg-10 col-md-10">
+        <h2 class="course-city-heading">Proběhlé kurzy a srazy</h2>
       </div>
-    {% endif %}
-    {% if meetups['past'] %}
-      <div class="row">
-        <div class="col-xs-12 col-sm-12 col-md-offset-1 col-lg-offset-1 col-lg-10 col-md-10">
-          <h2 class="course-city-heading">Proběhlé kurzy a srazy</h2>
-        </div>
-      </div>
-      <div class="row">
-        {% for meetup in meetups['past'] %}
+    </div>
+    <div class="row">
+      {% for meetup in meetups %}
+        {% if not meetup.current %}
           {{ meetup_info(meetup,  with_registration_link=False) }}
           {% if not loop.last and loop.index0 % 2 %}
             </div><div class="row">
           {% endif %}
-        {% endfor %}
-      </div>
-    {% endif %}
+        {% endif %}
+      {% endfor %}
+    </div>
 {% endmacro %}
 
 <!DOCTYPE html>


### PR DESCRIPTION
Všechny informace o kurzech jsou v datových souborech, takže není potřeba do `index.html` ručně přepisovat datumy, stav kurzů a odkazy na registrace.