### PR TITLE
Automatic `done` for lessons without `done` key in .yaml file

### DIFF
--- a/plans/ostrava.yml
+++ b/plans/ostrava.yml
@@ -1,6 +1,5 @@
 - name: Instalace
   date: 2017-09-12
-  done: false
   materials:
   - name: Úvodní prezentace
     type: lesson
@@ -22,7 +21,6 @@
     link: v1/s001-install/handout/handout.pdf
 - name: První program
   date: 2017-09-19
-  done: false
   materials:
   - name: První program
     type: lesson
@@ -47,7 +45,6 @@
     link: https://www.dropbox.com/request/ezM34x08V0ooGjIuzOJB
 - name: Cykly
   date: 2017-09-26
-  done: false
   materials:
   - name: Funkce
     type: lesson
@@ -66,7 +63,6 @@
     link: https://www.dropbox.com/request/dIghRsOtawUytP8qg3Yb
 - name: Jeden nový cyklus a procvičování
   date: 2017-10-03
-  done: false
   materials:
   - name: Cyklus `While`
     type: lesson
@@ -79,7 +75,6 @@
     link: https://www.dropbox.com/request/b4Yw8W42nSsm49UrzUqN
 - name: Funkce & Řetězce
   date: 2017-10-10
-  done: false
   materials:
   - name: Vlastní funkce
     type: lesson
@@ -98,7 +93,6 @@
     link: https://www.dropbox.com/request/gzMXJdksiODF1JEYGdiF
 - name: Práce se soubory
   date: 2017-10-17
-  done: false
   materials:
   - name: Soubory
     type: lesson
@@ -123,7 +117,6 @@
     link: https://www.dropbox.com/request/uQEtv4zPfMyKQMdGIQzL
 - name: Seznamy
   date: 2017-10-24
-  done: false
   materials:
   - name: Seznamy
     type: lesson
@@ -142,7 +135,6 @@
     link: https://www.dropbox.com/request/V0kzxqX19ICk7q7YSI8B
 - name: Slovníky
   date: 2017-10-31
-  done: false
   materials:
   - name: Slovníky
     type: lesson
@@ -164,7 +156,6 @@
     link: https://www.dropbox.com/request/RPoOQOyya1tmxr3ngLFO
 - name: Moduly a výjimky
   date: 2017-11-07
-  done: false
   materials:
   - name: Moduly
     type: lesson
@@ -183,7 +174,6 @@
     link: https://www.dropbox.com/request/mlgOENzebT3oRXEBdvMt
 - name: Testování a procvičování
   date: 2017-11-14
-  done: false
   materials:
   - name: Testování
     type: lesson
@@ -196,7 +186,6 @@
     link: https://www.dropbox.com/request/3HlBHVc8gAvZyCYZ9LvP
 - name: Grafika
   date: 2017-11-21
-  done: false
   materials:
   - name: Grafika
     type: lesson
@@ -212,7 +201,6 @@
     link: https://github.com/pyvec/cheatsheets/raw/master/pyglet/pyglet-basics-cs.pdf
 - name: Třídy
   date: 2017-11-28
-  done: false
   materials:
   - name: Třídy
     type: lesson
@@ -222,7 +210,6 @@
     link: http://naucse.python.cz/2017/pyladies-ostrava-podzim/beginners/inheritance/
 - name: Závěrečný projekt
   date: 2017-12-05
-  done: false
   materials:
   - name: Asteroids
     type: lesson
@@ -236,11 +223,9 @@
 - name: Pokračování závěrečného projektu
   date: 2017-12-12
   description: V této lekci budeme pokračovat v dalších fázích závěrečného projektu.
-  done: false
 - name: Závěrečná hodina
   date: 2017-12-19
   description: Během závěrečné hodiny si předáme diplomy a seznámíme se s možnostmi pokračování studia
-  done: false
 - name: Odbočky
   description: |
     Někdy je na sraze menší účast, tak zařadíme téma na přání,

--- a/pyladies_cz.py
+++ b/pyladies_cz.py
@@ -148,6 +148,15 @@ def read_lessons_yaml(filename):
         for mat in lesson.get('materials', ()):
             mat['name'] = convert_markdown(mat['name'], inline=True)
 
+        # If lesson has no `done` key, add them according to lesson dates
+        # All lesson's dates must be in past to mark it as done
+        done = lesson.get('done', None)
+        if done is None and 'dates' in lesson:
+            all_done = []
+            for date in lesson['dates']:
+                all_done.append(datetime.date.today() > date)
+            lesson['done'] = all(all_done)
+
     return data
 
 


### PR DESCRIPTION
U lekcí, které nemají natvrdo v yaml souboru uloženu informaci o tom, zda už proběhly nebo ne, se tato informace zjistí podle data konání lekce. Pokud jsou všechna data konání lekce v minulosti, označí se lekce automaticky jako hotová.

Usnadní to práci a přitom neovlivní nikoho, kdo si to bude chtít dále evidovat ručně v plánu kurzu.