### PR TITLE
twitter api: typo in the word "bearer" and missing print

### DIFF
--- a/original/v1/s011-dicts/requests.ipynb.html
+++ b/original/v1/s011-dicts/requests.ipynb.html
@@ -131,14 +131,14 @@ div#notebook {
   div.cell {
     display: block;
     page-break-inside: avoid;
-  } 
-  div.output_wrapper { 
-    display: block;
-    page-break-inside: avoid; 
   }
-  div.output { 
+  div.output_wrapper {
     display: block;
-    page-break-inside: avoid; 
+    page-break-inside: avoid;
+  }
+  div.output {
+    display: block;
+    page-break-inside: avoid;
   }
 }
 </style>
@@ -364,8 +364,12 @@ div#notebook {
 <div class="prompt input_prompt">In&nbsp;[6]:</div>
 <div class="inner_cell">
     <div class="input_area">
+
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">odpoved</span> <span class="o">=</span> <span class="n">requests</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;https://api.twitter.com/1.1/search/tweets.json&#39;</span><span class="p">)</span>
+
+<span class="nb">print</span><span class="p">(</span>
 <span class="n">odpoved</span><span class="o">.</span><span class="n">text</span>
+<span class="p">)</span>
 </pre></div>
 
 </div>
@@ -449,8 +453,12 @@ div#notebook {
 <span class="n">odpoved</span> <span class="o">=</span> <span class="n">requests</span><span class="o">.</span><span class="n">post</span><span class="p">(</span><span class="s1">&#39;https://api.twitter.com/oauth2/token&#39;</span><span class="p">,</span>
                         <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
                         <span class="n">data</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;grant_type&#39;</span><span class="p">:</span> <span class="s1">&#39;client_credentials&#39;</span><span class="p">})</span>
+
+<span class="nb">print</span><span class="p">(</span>
 <span class="n">odpoved</span><span class="o">.</span><span class="n">text</span>
+<span class="p">)</span>
 </pre></div>
+
 
 </div>
 </div>
@@ -519,7 +527,7 @@ div#notebook {
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Tohle heslo si můžeš zapsat přímo do programu, a jeho získávání příště přeskočit (místo všeho od <code>api_key = ...</code> napsat jen <code>berarer_token = 'AAAA...'</code>.</p>
+<p>Tohle heslo si můžeš zapsat přímo do programu, a jeho získávání příště přeskočit (místo všeho od <code>api_key = ...</code> napsat jen <code>bearer_token = 'AAAA...'</code>.</p>
 <p>Blížíme se ke konci! Teď si uděláme si objekt <code>Session</code> s nastavenými přihlašovacími údaji. Tím řekneme knihovně Requests, aby tohle nové heslo používala pro další dotazy.</p>
 
 </div>


### PR DESCRIPTION
twitter api, requests: je tam typo ve slove "bearer" a asi chybi 2x "print", aby se mohl vypsat output s chybou atd. Co myslite? Zkousela jsem to rovnou opravit v html, tak snad to nejak vyslo..