### PR TITLE
Novinky na hlavní stránce

### DIFF
--- a/news.yml
+++ b/news.yml
@@ -1,0 +1,11 @@
+- title: MicroPython workshop v Ostravě
+  expires: 2018-03-10
+  content: |
+    Chcete se naučit dalšímu nesmírně praktickému využití Pythonu? Co třeba ovládat micropočítače, LED světla, motory a další?
+    Přijďte na MicroPython workshop do Ostravy. <a href="https://goo.gl/forms/U33YfjxMFtOXqiEq1" target="_blank">Registrace zde</a>
+
+- title: Workshop programování v Hradci Králové
+  expires: 2018-03-14
+  content: |
+    Náš první workshop programování pro začátečnice v Hradci Králové je tu! Konat se bude 25. března a
+    registrovat se na něj <a href="https://docs.google.com/forms/d/e/1FAIpQLScO5in0gzo13ddLcc1q508beqc5RGp6Dpd-3XGGP9HrF_47rg/viewform" target="_blank">můžeš zde</a>

--- a/pyladies_cz.py
+++ b/pyladies_cz.py
@@ -48,7 +48,10 @@ def index():
     current_meetups = collections.OrderedDict(
         (city, read_meetups_yaml('meetups/{}.yml'.format(city)))
         for city in ('praha', 'brno', 'ostrava'))
-    return render_template('index.html', current_meetups=current_meetups)
+    news = read_news_yaml('news.yml')
+    return render_template('index.html',
+                           current_meetups=current_meetups,
+                           news=news)
 
 
 @app.route('/brno_info/')
@@ -240,6 +243,16 @@ def read_meetups_yaml(filename):
 
     return list(reversed(data))
 
+def read_news_yaml(filename):
+    data = read_yaml(filename)
+    today = datetime.date.today()
+    news = []
+
+    for new in data:
+        if new['expires'] >= today:
+            news.append(new)
+
+    return news
 
 def pathto(name, static=False):
     if static:

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -287,22 +287,20 @@ HOMEPAGE
     margin-bottom: 20px;
 }
 
-#news-summer {
+#news {
     padding-top: 50px;
     padding-bottom: 30px;
 }
+#news-main-title {
+    margin: 0;
+    color: #000000;
+}
 .news-title {
-  margin-bottom: 70px;
+  margin-bottom: 20px;
   color: #000000;
 }
-.news-summer-p {
-  padding: 40px 30px;
-  height: auto;
-  overflow: hidden;
-  min-height: 600px;
-  max-height: 800px;
-  padding-bottom: 85px;
-  padding-top: 25px;
+.news-p {
+  padding: 40px 40px 40px 0;
   color: #8e8c8d;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,37 +15,25 @@
     </header>
 
     <!-- News Section -->
-    <!-- <section id="news-summer" class="container content-section text-center">
-      <div class="row">
-        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-          <h1 class="news-title">Letní novinky</h1>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
-          <div class="news-summer-p">
-          <a href="https://github.com/micropython/micropython"><img height="110" src="{{ pathto('_static/img/icon/micropython.png', 1) }}" class="keyfeature-icon"></a>
-          <h3 class="news-title">Praha - začátečnický kurz</h3>Kurz začne 13. září 2016 a bude sestávat ze zhruba 13&nbsp;dvouhodinových setkání. Tím pádem pojedeme až do půlky prosince.
-          Budeme se scházet jednou týdně, ve vybavených prostorách naší partnerské firmy <a href="http://www.nic.cz">CZ.NIC</a> v&nbsp;blízkosti náměstí Jiřího&nbsp;z&nbsp;Poděbrad. Setkání probíhá v&nbsp;úterý od&nbsp;18&nbsp;do&nbsp;20&nbsp;hod.
-          (Pokud s&nbsp;jistotou víš, že v&nbsp;tuto dobu nemůžeš, můžeš zkusit pracovat samostatně dle učebních materiálů, případně si zkusit na FB&nbsp;skupině najít kolegyni nebo domluvit individuální konzultace).
-          Celkově je kurz poměrně časově náročný, mezi jednotlivými srazy je zapotřebí pracovat i&nbsp;samostatně na domácích projektech, které pomáhají osvojit si nově probrané téma. Zvaž prosím, jestli budeš mít na PyLadies v následujících měsících dost času, výsledné dovednosti ale stojí určitě za to. :)
-          <br>Pokud máš nějaké otázky, neváhej se zeptat na <a href="https://www.facebook.com/groups/pyladiespraha/?fref=ts">FB skupině PyLadies Praha</a>.
-
-          </div>
-        </div>
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
-          <div class="news-summer-p">
-            <img height="110" src="{{ pathto('_static/img/icon/pylady-ostrava.png', 1) }}" class="keyfeature-icon">
-          <h3 class="news-title">Příprava kurzů v Ostravě</h3>
-             V Ostravě připravují na podzim 2016 vůbec první kurz Pythonu pro holky. A&nbsp;to díky slečnám, které se rozhodly, že by se Python rády naučily. Daly se dohromady s&nbsp;místním pythonistou a&nbsp;organizátorem ostravských python meetupů Pyvo, Lumírem.
-             Nyní se již snaží společnými silami vše na podzim připravit.
-            <br>Kontaktovat organizátory ostravských PyLadies <a href="mailto:pyladies-ostrava@googlegroups.com">můžeš už nyní</a>.
-            <br>Pokud bys ráda zorganizovala PyLadies ve svém městě a díky tomu se i Python naučila bez zbytečného dojíždění, dej nám <a href="mailto:encukou@gmail.com">vědět</a>, pomůžeme Ti :-) Nějaké základní informace, najdeš sepsané <a href="http://pyladies.cz/stan_se/">i tady</a>.
-          </div>
-        </div>
-      </div>
-    </section>
-      -->
+    {% if news %}
+        <section id="news" class="container content-section text-center">
+            <div class="row">
+                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+                <h1 id="news-main-title">Novinky</h1>
+                </div>
+            </div>
+            <div class="row">
+                {% for new in news %}
+                <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+                    <div class="news-p">
+                    <h3 class="news-title">{{ new.title }}</h3>
+                        {{ new.content|safe }}
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </section>
+    {% endif %}
     <!-- About Section -->
     <section id="about" class="container content-section text-center">
         <div class="row">


### PR DESCRIPTION
Po diskusi na Slacku se @zuzejk a @honzajavorek jsem implementoval snadný způsob, jak dávat na hlavní stránku novinky. Také mi něco takového chybělo, protože jsem chtěl najednou promovat více akcí a sekce s odkazy na kurzy se na to úplně nehodí. Vyšel jsem z novinek, které tam byly už několik let zakomentované.

Vytvořil jsem pro to další yaml soubor, kam je možné je dávat i s datem jejich expirace, po kterém se přestanou zobrazovat. Pokud nebude v danou chvíli žádná aktivní novinka, celá sekce se skryje. Pokud by to bylo žádané, je možné přidat i datum začátku platnosti dané novinky.

Ve finále to vypadá nějak takto:
![screenshot-2018-2-10 pyladies cz](https://user-images.githubusercontent.com/5688939/36066369-83f0360a-0ea8-11e8-9d00-c48d75eecf28.png)
