### PR TITLE
Display registration links highlighted (#501)

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -603,6 +603,9 @@ CITIES PAGE
 .meetup ul li.button a.meetup-info-item:hover {
   background-color: #e51f40;
 }
+.meetup ul li.button.highlight .meetup-info-item {
+  background-color: #e51f40;
+}
 .meetup ul li a.meetup-info-item {
   color: #e51f40;
 }

--- a/templates/city.html
+++ b/templates/city.html
@@ -7,8 +7,8 @@
 {%- endblock -%}
 
 {% macro meetup_info(meetup, with_registration_link=True) %}
-  {% macro item(icon, url=None, is_button=False) %}
-    <li {% if is_button %}class="button"{% endif %}>
+  {% macro item(icon, url=None, is_button=False, highlight=False) %}
+    <li {% if is_button %}class="button{% if highlight %} highlight{% endif %}"{% endif %}>
         {% if url %}
             <a href="{{ url }}"
         {% else %}
@@ -53,7 +53,7 @@
       {% set have_button=False %}
       {% if meetup.registration_status and with_registration_link %}
         {% if meetup.registration_status == 'running' %}
-          {% call item(icon="edit", url=meetup.registration.url, is_button=True) %}
+          {% call item(icon="edit", url=meetup.registration.url, is_button=True, highlight=True) %}
             {{ meetup.registration.get('text', 'Registrace právě probíhá!') }}
           {% endcall %}
           {% set have_button=True %}


### PR DESCRIPTION
Currently there is no significant visual difference between "Materiály"
and "Registrace právě probíhá". This patch introduce new CSS class to
display this link highlighted.