### PR TITLE
Fix Barclays logo wrong link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -175,7 +175,7 @@
             </a>
         </div>
         <div class="partner col-xs-6 col-sm-4">
-            <a href="http://www.kinali.cz/en/" target="_blank" rel="noopener">
+            <a href="https://search.jobs.barclays/barclays-developers-prague" target="_blank" rel="noopener">
                 <img class="partner-logo img-responsive center-block" src="{{ pathto('_static/img/logo/barclays.svg', 1) }}" />
             </a>
         </div>
@@ -206,4 +206,3 @@
         </div>
     </section>
 {% endblock content %}
-    


### PR DESCRIPTION
Barclays logo on the main page had incorrect hyperlink, now it is fixed.