### PR TITLE
Set up GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,7 @@
 name: Main
 on:
   push:
-    branches:
-      - master
   pull_request:
-    branches:
-      - master
   schedule:
     - cron: "30 2 * * *"
 jobs:
@@ -23,7 +19,8 @@ jobs:
     - name: Freeze HTML
       run: |
         python pyladies_cz.py freeze
-    - name: Deploy
+    - if: ${{ github.ref == 'refs/heads/master' }}
+      name: Deploy
       run: |
         python pyladies_cz.py deploy --no-freeze --push
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+name: Main
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "30 2 * * *"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python -m pip install -r requirements.txt
+    - name: Freeze HTML
+      run: |
+        python pyladies_cz.py freeze
+    - name: Deploy
+      run: |
+        python pyladies_cz.py deploy --no-freeze --push
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Řeší #635 
Job by se měl spustit na push a pull request do branche master, a každý den ve 2.30 h. 
Oproti konfiguráku pro travis se zde neřeší cache ([dají se přidat](https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows)).