### PR TITLE
Remove mention of the JG newsletter

### DIFF
--- a/templates/faq.html
+++ b/templates/faq.html
@@ -49,7 +49,7 @@
 
                 <h3>Mám za sebou kurz PyLadies a chci si najít první práci v IT. Co mám dělat?</h3>
                 <p>
-                    Mrkni na web <a href="https://junior.guru/">junior.guru</a>, kde najdeš tipy v tomto směru i pracovní nabídky. Autor stránek přímo spolupracuje s PyLadies. K zasílání pracovních nabídek e-mailem se můžeš také <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9Uh01R-uJj6B4Pyzi5rzKhlMoePTWKAhrtCqT-enaJy4rmQ/viewform?usp=sf_link">přihlásit u nás</a>.
+                    Mrkni na web <a href="https://junior.guru/">junior.guru</a>, kde najdeš tipy v tomto směru i pracovní nabídky. Autor stránek přímo spolupracuje s PyLadies. K zasílání pracovních nabídek e-mailem se můžeš <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9Uh01R-uJj6B4Pyzi5rzKhlMoePTWKAhrtCqT-enaJy4rmQ/viewform?usp=sf_link">přihlásit i u přímo nás</a>.
                     <br />
                     Mimo to můžeme poskytnout konzultace a v některých oblastech i přímé kontakty na firmy, kde mají o začínající programátorky zájem. Python komunita se v tomto ohledu snaží být velmi nápomocná, tak se hlavně neboj toho využít.
                 </p>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -49,7 +49,7 @@
 
                 <h3>Mám za sebou kurz PyLadies a chci si najít první práci v IT. Co mám dělat?</h3>
                 <p>
-                    Mrkni na web <a href="https://junior.guru/">junior.guru</a>, kde najdeš tipy v tomto směru i pracovní nabídky. Autor stránek přímo spolupracuje s PyLadies. <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9Uh01R-uJj6B4Pyzi5rzKhlMoePTWKAhrtCqT-enaJy4rmQ/viewform?usp=sf_link">Přihlaš se</a> k zasílání pracovních nabídek e-mailem.
+                    Mrkni na web <a href="https://junior.guru/">junior.guru</a>, kde najdeš tipy v tomto směru i pracovní nabídky. Autor stránek přímo spolupracuje s PyLadies. K zasílání pracovních nabídek e-mailem se můžeš také <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9Uh01R-uJj6B4Pyzi5rzKhlMoePTWKAhrtCqT-enaJy4rmQ/viewform?usp=sf_link">přihlásit u nás</a>.
                     <br />
                     Mimo to můžeme poskytnout konzultace a v některých oblastech i přímé kontakty na firmy, kde mají o začínající programátorky zájem. Python komunita se v tomto ohledu snaží být velmi nápomocná, tak se hlavně neboj toho využít.
                 </p>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -49,7 +49,7 @@
 
                 <h3>Mám za sebou kurz PyLadies a chci si najít první práci v IT. Co mám dělat?</h3>
                 <p>
-                    Mrkni na web <a href="https://junior.guru/">junior.guru</a>, kde najdeš tipy v tomto směru i pracovní nabídky. Autor stránek přímo spolupracuje s PyLadies. Přihlaš se <a href="http://eepurl.com/gyG8Bb">na junior.guru</a> i <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9Uh01R-uJj6B4Pyzi5rzKhlMoePTWKAhrtCqT-enaJy4rmQ/viewform?usp=sf_link">u nás na PyLadies</a> k zasílání pracovních nabídek e-mailem.
+                    Mrkni na web <a href="https://junior.guru/">junior.guru</a>, kde najdeš tipy v tomto směru i pracovní nabídky. Autor stránek přímo spolupracuje s PyLadies. <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9Uh01R-uJj6B4Pyzi5rzKhlMoePTWKAhrtCqT-enaJy4rmQ/viewform?usp=sf_link">Přihlaš se</a> k zasílání pracovních nabídek e-mailem.
                     <br />
                     Mimo to můžeme poskytnout konzultace a v některých oblastech i přímé kontakty na firmy, kde mají o začínající programátorky zájem. Python komunita se v tomto ohledu snaží být velmi nápomocná, tak se hlavně neboj toho využít.
                 </p>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -49,7 +49,7 @@
 
                 <h3>Mám za sebou kurz PyLadies a chci si najít první práci v IT. Co mám dělat?</h3>
                 <p>
-                    Mrkni na web <a href="https://junior.guru/">junior.guru</a>, kde najdeš tipy v tomto směru i pracovní nabídky. Autor stránek přímo spolupracuje s PyLadies. Pokud nějaká firma osloví PyLadies osloví, snažíme se nabídku také rozeslat e-mailem skrze newsletter. Můžeš se do něj <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9Uh01R-uJj6B4Pyzi5rzKhlMoePTWKAhrtCqT-enaJy4rmQ/viewform?usp=sf_link">přihlásit</a>.
+                    Mrkni na web <a href="https://junior.guru/">junior.guru</a>, kde najdeš tipy v tomto směru i pracovní nabídky. Autor stránek spolupracuje s PyLadies. Pokud nějaká firma přímo osloví PyLadies, snažíme se nabídku také rozeslat e-mailem. K těmto e-mailům se můžeš přihlásit <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9Uh01R-uJj6B4Pyzi5rzKhlMoePTWKAhrtCqT-enaJy4rmQ/viewform?usp=sf_link">tímto formulářem</a>.
                     <br />
                     Mimo to můžeme poskytnout konzultace a v některých oblastech i přímé kontakty na firmy, kde mají o začínající programátorky zájem. Python komunita se v tomto ohledu snaží být velmi nápomocná, tak se hlavně neboj toho využít.
                 </p>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -49,7 +49,7 @@
 
                 <h3>Mám za sebou kurz PyLadies a chci si najít první práci v IT. Co mám dělat?</h3>
                 <p>
-                    Mrkni na web <a href="https://junior.guru/">junior.guru</a>, kde najdeš tipy v tomto směru i pracovní nabídky. Autor stránek přímo spolupracuje s PyLadies. K zasílání pracovních nabídek e-mailem se můžeš <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9Uh01R-uJj6B4Pyzi5rzKhlMoePTWKAhrtCqT-enaJy4rmQ/viewform?usp=sf_link">přihlásit i u přímo nás</a>.
+                    Mrkni na web <a href="https://junior.guru/">junior.guru</a>, kde najdeš tipy v tomto směru i pracovní nabídky. Autor stránek přímo spolupracuje s PyLadies. Pokud nějaká firma osloví PyLadies osloví, snažíme se nabídku také rozeslat e-mailem skrze newsletter. Můžeš se do něj <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9Uh01R-uJj6B4Pyzi5rzKhlMoePTWKAhrtCqT-enaJy4rmQ/viewform?usp=sf_link">přihlásit</a>.
                     <br />
                     Mimo to můžeme poskytnout konzultace a v některých oblastech i přímé kontakty na firmy, kde mají o začínající programátorky zájem. Python komunita se v tomto ohledu snaží být velmi nápomocná, tak se hlavně neboj toho využít.
                 </p>


### PR DESCRIPTION
I intend to eventually sunset the newsletter. It's better if they just go to the web and check the job postings there.