### PR TITLE
Fix mailto link subject field

### DIFF
--- a/templates/faq.html
+++ b/templates/faq.html
@@ -56,7 +56,7 @@
 
                 <h3>Jsme firma a zajímá nás spolupráce s PyLadies</h3>
                 <p>
-                    <a href="mailto:info@pyladies.cz?subject:Pylaides: Moznosti spoluprace">Dejte nám o sobě vědět!</a> Rádi zprostředkujeme Vaše nabídky pracovního uplatnění, pokud jsou vhodné pro začínající programátorky. Pokud chcete podpořit naše aktivity, jakožto nezisková iniciativa vítáme i možnosti sponzorské spolupráce.
+                    <a href="mailto:info@pyladies.cz?subject=PyLadies: Moznosti spoluprace">Dejte nám o sobě vědět!</a> Rádi zprostředkujeme Vaše nabídky pracovního uplatnění, pokud jsou vhodné pro začínající programátorky. Pokud chcete podpořit naše aktivity, jakožto nezisková iniciativa vítáme i možnosti sponzorské spolupráce.
                     <br>
                     Kromě toho nás potěší, pokud vypíšete juniorní nabídky práce pro naše absolventky a dáte nám o nich vědět nebo je rovnou vyvěsíte na <a href="https://junior.guru/jobs/">junior.guru</a>.
                 </p>


### PR DESCRIPTION
According to the [internets](https://www.w3docs.com/snippets/html/how-to-create-mailto-links.html) the subject has to be composed differently than we had it. Checked with my mail client I can confirm it didn't work previously (the subject field remained empty) and it works now with the fix. An ugly typo was fixed on the way.