### PR TITLE
Code cleanup

### DIFF
--- a/pyladies_cz.py
+++ b/pyladies_cz.py
@@ -174,31 +174,6 @@ def read_yaml(filename, default=MISSING):
         data = yaml.safe_load(file)
     return data
 
-def read_lessons_yaml(filename):
-    data = read_yaml(filename)
-
-    # workaround for http://stackoverflow.com/q/36157569/99057
-    # Convert datetime objects to strings
-    for lesson in data:
-        if 'date' in lesson:
-            lesson['dates'] = [lesson['date']]
-        if 'description' in lesson:
-            lesson['description'] = convert_markdown(lesson['description'],
-                                                     inline=True)
-        for mat in lesson.get('materials', ()):
-            mat['name'] = convert_markdown(mat['name'], inline=True)
-
-        # If lesson has no `done` key, add them according to lesson dates
-        # All lesson's dates must be in past to mark it as done
-        done = lesson.get('done', None)
-        if done is None and 'dates' in lesson:
-            all_done = []
-            for date in lesson['dates']:
-                all_done.append(datetime.date.today() > date)
-            lesson['done'] = all(all_done)
-
-    return data
-
 
 def read_meetups_yaml(filename):
     data = read_yaml(filename)

--- a/pyladies_cz.py
+++ b/pyladies_cz.py
@@ -17,8 +17,8 @@ from pathlib import Path, PurePosixPath
 from flask import Flask, render_template, url_for, send_from_directory
 from flask_frozen import Freezer
 import yaml
-import jinja2
 import markdown
+import markupsafe
 
 from elsa import cli
 
@@ -141,7 +141,7 @@ md = markdown.Markdown(extensions=['meta', 'markdown.extensions.toc'])
 
 @app.template_filter('markdown')
 def convert_markdown(text, inline=False):
-    result = jinja2.Markup(md.convert(text))
+    result = markupsafe.Markup(md.convert(text))
     if inline and result[:3] == '<p>' and result[-4:] == '</p>':
         result = result[3:-4]
     return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML
 elsa>=0.1.2
-jinja2
 markdown
+markupsafe


### PR DESCRIPTION
- replace deprecated jinja2.Markup with markupsafe.Markup - it is used when rendering News on the main page - I checked it and it still looks fine
- delete a function `read_lessons_yaml` that is not called anywhere anymore - I compared the output of `freeze` command with and without the function, it seems it doesn't break anything + the pages are displayed correctly locally.