### PR TITLE
Make it possible to add more materials/links to meetups

### DIFF
--- a/meetups/ostrava.yml
+++ b/meetups/ostrava.yml
@@ -221,3 +221,13 @@
     name: Moravskoslezská vědecká knihovna v Ostravě
     address: Prokešovo náměstí 1802/9, Ostrava, 70200
     url: https://maps.app.goo.gl/ahdR8vw1LDw3ic6y5
+
+- name: Online mentoring
+  topic: Indivuduální online mentoring týkající se Pythonu nebo příbuzných témat
+  start: 2023-09-20
+  end: 2024-06-30
+  place:
+    name: online
+  materials:
+    Příručka online mentoringu: https://docs.google.com/document/d/1LGhQ2DZju5YoLx3J_R5iQsyNy-K0b2zNw09Pf6hW2PQ/edit?usp=sharing
+    Online mentoring guide: https://docs.google.com/document/d/1OnQ5ku3weVDd0gTNe8uQuxTRtz3neMwhxm37NcVqMS4/edit?usp=sharing

--- a/templates/city.html
+++ b/templates/city.html
@@ -73,10 +73,19 @@
         {% endif %}
       {% endif %}
       {% if meetup.materials %}
-        {% call item(icon="book", url=meetup.materials,
-                     is_button=not have_button and meetup.current) %}
-          Materiály
-        {% endcall %}
+        {% if meetup.materials is mapping %}
+          {% for anchor_text, url in meetup.materials.items() %}
+            {% call item(icon="book", url=url,
+                        is_button=not have_button and meetup.current) %}
+              {{ anchor_text }}
+            {% endcall %}
+          {% endfor %}
+        {% else %}
+          {% call item(icon="book", url=meetup.materials,
+                      is_button=not have_button and meetup.current) %}
+            Materiály
+          {% endcall %}
+        {% endif %}
       {% endif %}
       </ul>
   </div>


### PR DESCRIPTION
I need this feature to be able to link to more than one URL/document for a single meetup. Backwards-compatible change.

Result:

![Screenshot from 2024-02-13 12-21-41](https://github.com/PyLadiesCZ/pyladies.cz/assets/5688939/2e93b36e-1097-4627-87c2-cfcb5d90ca8b)
