### PR TITLE
Add team alumni section

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ Pokud kouč nechce zveřejňovat fotku, jako `img` uveď prázdný avatar:
   role: Koučka
 ```
 
+Pokud je daný kouč/koučka v komunitě již neaktivní, můžete jim přidat vlastnost `alumni: true`.
+Tito bývalí členové se poté vypíšou v separátní sekci. Takto můžeme oddělit aktivní a neaktivní
+členy komunity, a zároveň vzdát hold členům, kteří v minulosti PyLadies pomáhali organizovat.
+
 Volitelně se můžou nastavit odkazy na další profily. Žádný údaj není povinný.
 
 ```

--- a/pyladies_cz.py
+++ b/pyladies_cz.py
@@ -65,6 +65,16 @@ def city(city_slug):
     past_meetups = [m for m in meetups if not m['current']]
     registration_meetups = [
         m for m in current_meetups if m.get('registration_status')=='running']
+
+    members = read_yaml('teams/' + city_slug + '.yml', default=())
+    team = []
+    alumni = []
+    for member in members:
+        if member.get("alumni", False):
+            alumni.append(member)
+        else:
+            team.append(member)
+
     return render_template(
         'city.html',
         city_slug=city_slug,
@@ -75,7 +85,8 @@ def city(city_slug):
         past_meetups=past_meetups,
         registration_meetups=registration_meetups,
         contacts=city.get('contacts'),
-        team=read_yaml('teams/' + city_slug + '.yml', default=()),
+        team=team,
+        alumni=alumni
     )
 
 @app.route('/<city>_course/')

--- a/templates/city.html
+++ b/templates/city.html
@@ -344,6 +344,13 @@
     </section>
     {% endif %}
 
+    {% if alumni %}
+    <!-- Alumni section -->
+      <section id="alumni" class="container" >
+        {{ team_section("Bývalí členové komunity", alumni) }}
+      </section>
+    {% endif %}
+
   <!-- Past Meetups -->
   {% if past_meetups %}
   <section  class=" container text-center" id="past-meetups">

--- a/templates/city.html
+++ b/templates/city.html
@@ -110,6 +110,26 @@
     {% endif %}
 {% endmacro %}
 
+{% macro team_section(name, team) %}
+  <h2 class="course-city-heading">{{ name }}</h2>
+  <div class="team ">
+    {% for member in team %}
+      <div class="person">
+        <div class="member-photo">
+          <img src="{{ url_for('static', filename=member.img or 'img/brno/team/blank.png') }}" class="img-circle" />
+        </div>
+        <h5 class="member-name"><strong>{{ member.name }}</strong></h5>
+        <span><em>{{ member.role }}</em></span>
+        <ul>
+          {%- for link in member.links -%}{%- for type, url in link.items() -%}
+            <li><a href="{{ url }}"><img src="{{ url_for('static', filename='img/icon/{}.png'.format(type)) }}" /></a></li>
+          {%- endfor -%}{%- endfor -%}
+        </ul>
+      </div>
+    {% endfor %}
+  </div>
+{% endmacro %}
+
 {% block content %}
   <!-- Intro Header -->
   <header class="intro-city">
@@ -320,23 +340,7 @@
     {% if team %}
     <!-- Team section -->
     <section id="team" class="container" >
-      <h2 class="course-city-heading">{{ team_name }}</h2>
-      <div class="team ">
-        {% for member in team %}
-          <div class="person">
-            <div class="member-photo">
-              <img src="{{ url_for('static', filename=member.img or 'img/brno/team/blank.png') }}" class="img-circle" />
-             </div>
-            <h5 class="member-name"><strong>{{ member.name }}</strong></h5>
-            <span><em>{{ member.role }}</em></span>
-            <ul>
-              {%- for link in member.links -%}{%- for type, url in link.items() -%}
-                <li><a href="{{ url }}"><img src="{{ url_for('static', filename='img/icon/{}.png'.format(type)) }}" /></a></li>
-              {%- endfor -%}{%- endfor -%}
-            </ul>
-          </div>
-        {% endfor %}
-      </div>
+      {{ team_section(team_name, team) }}
     </section>
     {% endif %}
 


### PR DESCRIPTION
This was discussed [here](https://github.com/PyLadiesCZ/pyladies.cz/pull/791#discussion_r1957298710). It seems that non-active community members are being simply removed from the pyladies.cz web, which is IMO a shame! I think that we should acknowledge the past members of our community, rather than just remove them from the website. For example, [this](https://www.rust-lang.org/governance/teams/compiler#team-rust-analyzer) is how Rust does it (notice the "alumni" section).

This PR adds a separate section for "alumni", which can be marked as such in the YAML file. This is how it looks like:

![image](https://github.com/user-attachments/assets/fef23960-12a2-4042-bfe8-ac3642cf7474)

We could collapse it by default or make the icons/names of alumni members smaller if you feel that it takes too much space, but I think that it's fine the way it is.